### PR TITLE
feat: Allow port option for launching chromium browser

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -50,6 +50,7 @@ export default async function run(
     chromiumBinary,
     chromiumPref,
     chromiumProfile,
+    chromiumPort,
   },
   {
     buildExtension = defaultBuildExtension,
@@ -194,6 +195,7 @@ export default async function run(
       chromiumBinary,
       chromiumProfile,
       customChromiumPrefs,
+      chromiumPort,
     };
 
     const chromiumRunner = await createExtensionRunner({

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -207,6 +207,14 @@ export class ChromiumExtensionRunner {
       chromeFlags.push(...startingUrls);
     }
 
+    let port;
+    if (this.params.chromiumPort) {
+      if (!isNaN(this.params.chromiumPort)) {
+        port = this.params.chromiumPort;
+        log.debug(`(port: ${port})`);
+      }
+    }
+
     this.chromiumInstance = await this.chromiumLaunch({
       enableExtensions: true,
       chromePath: chromiumBinary,
@@ -216,6 +224,7 @@ export class ChromiumExtensionRunner {
       // Ignore default flags to keep the extension enabled.
       ignoreDefaultFlags: true,
       prefs: this.getPrefs(),
+      ...(typeof port !== 'undefined' ? { port } : {}),
     });
 
     this.chromiumInstance.process.once('close', () => {

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -208,11 +208,9 @@ export class ChromiumExtensionRunner {
     }
 
     let port;
-    if (this.params.chromiumPort) {
-      if (!isNaN(this.params.chromiumPort)) {
-        port = this.params.chromiumPort;
-        log.debug(`(port: ${port})`);
-      }
+    if (this.params.chromiumPort && !isNaN(this.params.chromiumPort)) {
+      port = this.params.chromiumPort;
+      log.debug(`(port: ${port})`);
     }
 
     this.chromiumInstance = await this.chromiumLaunch({
@@ -224,7 +222,7 @@ export class ChromiumExtensionRunner {
       // Ignore default flags to keep the extension enabled.
       ignoreDefaultFlags: true,
       prefs: this.getPrefs(),
-      ...(typeof port !== 'undefined' ? { port } : {}),
+      port,
     });
 
     this.chromiumInstance.process.once('close', () => {

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -668,6 +668,24 @@ describe('util/extension-runners/chromium', async () => {
     await runnerInstance.exit();
   });
 
+  it('does pass port to chrome', async () => {
+    const { params } = prepareExtensionRunnerParams({
+      params: {
+        port: 31269,
+      },
+    });
+
+    const runnerInstance = new ChromiumExtensionRunner(params);
+    await runnerInstance.run();
+
+    sinon.assert.calledOnce(params.chromiumLaunch);
+    sinon.assert.calledWithMatch(params.chromiumLaunch, {
+      port: 31269,
+    });
+
+    await runnerInstance.exit();
+  });
+
   describe('reloadAllExtensions', () => {
     let runnerInstance;
     let wsClient;

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -669,9 +669,10 @@ describe('util/extension-runners/chromium', async () => {
   });
 
   it('does pass port to chrome', async () => {
+    const port = 31269;
     const { params } = prepareExtensionRunnerParams({
       params: {
-        port: 31269,
+        chromiumPort: port,
       },
     });
 
@@ -680,7 +681,7 @@ describe('util/extension-runners/chromium', async () => {
 
     sinon.assert.calledOnce(params.chromiumLaunch);
     sinon.assert.calledWithMatch(params.chromiumLaunch, {
-      port: 31269,
+      port,
     });
 
     await runnerInstance.exit();


### PR DESCRIPTION
This suggestion allows us to specify a port when launching Chrome.  While we can easily add the "remote-debugging-port" option to vite.config.ts, the option doesn't get picked up by web-ext and results in a connection failure error shortly after launching a debugging session.

In absence of a port option, web-ext chooses a random port when launching .  By specifying a specific port, it makes it easier to attach to the spawned browser with a debugger during testing.