### PR TITLE
feat: Allow excluding "Reload Manager" extension

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -31,6 +31,7 @@ export default async function run(
     noInput = false,
     noReload = false,
     preInstall = false,
+    noReloadManagerExtension = false,
     sourceDir,
     watchFile,
     watchIgnored,
@@ -194,6 +195,7 @@ export default async function run(
       chromiumBinary,
       chromiumProfile,
       customChromiumPrefs,
+      noReloadManagerExtension,
     };
 
     const chromiumRunner = await createExtensionRunner({

--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -136,7 +136,9 @@ export class ChromiumExtensionRunner {
     this.reloadManagerExtension = await this.createReloadManagerExtension();
 
     // Start chrome pointing it to a given profile dir
-    const extensions = [this.reloadManagerExtension]
+    const extensions = (
+      this.params.noReloadManagerExtension ? [] : [this.reloadManagerExtension]
+    )
       .concat(this.params.extensions.map(({ sourceDir }) => sourceDir))
       .join(',');
 


### PR DESCRIPTION
WXT manages reloading the extension internally, so we don't need to install the "Reload Manager" extension.

This also fixes https://github.com/aklinker1/vite-plugin-web-extension/issues/196 and https://github.com/wxt-dev/wxt/security/dependabot/6