### PR TITLE
feat: remove --disable-component-update from default args

### DIFF
--- a/src/extension-runners/chromium.js
+++ b/src/extension-runners/chromium.js
@@ -21,7 +21,11 @@ import fileExists from '../util/file-exists.js';
 
 const log = createLogger(import.meta.url);
 
-const EXCLUDED_CHROME_FLAGS = ['--disable-extensions', '--mute-audio'];
+const EXCLUDED_CHROME_FLAGS = [
+  '--disable-extensions',
+  '--mute-audio',
+  '--disable-component-update',
+];
 
 export const DEFAULT_CHROME_FLAGS = ChromeLauncher.defaultFlags().filter(
   (flag) => !EXCLUDED_CHROME_FLAGS.includes(flag),

--- a/tests/unit/test-extension-runners/test.chromium.js
+++ b/tests/unit/test-extension-runners/test.chromium.js
@@ -52,7 +52,6 @@ describe('util/extension-runners/chromium', async () => {
       '--disable-features=Translate,OptimizationHints,MediaRouter,DialMediaRouteProvider,CalculateNativeWinOcclusion,InterestFeedContentSuggestions,CertificateTransparencyComponentUpdater,AutofillServerCommunication',
       '--disable-component-extensions-with-background-pages',
       '--disable-background-networking',
-      '--disable-component-update',
       '--disable-client-side-phishing-detection',
       '--disable-sync',
       '--metrics-recording-only',


### PR DESCRIPTION
Similarly to mozilla/web-ext#3298, 
Quoting:
> Summarizing the “why” here:  
The --disable-component-update command-line flag does two things: it disables component updates (desired) but it also prevents any bundled components from being initialised (undesired).

Disable this flag grant more flexibility, and it can always be disabled via the `web-ext run --arg option`

@aklinker1 Could you please check this PR? I would like to propagate the change to your [vite-plugin-web-extension](https://github.com/aklinker1/vite-plugin-web-extension)